### PR TITLE
Updates colorama version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies
-colorama==0.3.6
+colorama>=0.3.6
 
 # Testing and Development
 #nose==1.3.7


### PR DESCRIPTION
The colorama dependency presents a version conflict when using commis in conjunction with the [halo](https://github.com/manrajgrover/halo) or [log-symbols](https://github.com/manrajgrover/py-log-symbols) packages.

```
ERROR: log-symbols 0.0.13 has requirement colorama==0.3.9, but you'll have colorama 0.4.1 which is incompatible.
ERROR: halo 0.0.26 has requirement colorama==0.3.9, but you'll have colorama 0.4.1 which is incompatible.
```

This PR modifies the colorama dependency from `colorama==0.3.6` to `colorama>=0.3.6` for better compatibility with these packages.